### PR TITLE
MVC1　分類情報管理画面への画面遷移、HelloWorld出力

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
@@ -26,6 +26,9 @@ public class UrlConsts {
 	// 在庫センター情報画面 検索
 	public static final String CENTER_INFO_SEARCH = "/admin/centerInfo/search";
 
+	// 分類情報画面
+	public static final String  CATEGORY_INFO = "/admin/categoryInfo";
+	
 	// 認証不要画面
 	public static final String[] NO_AUTHENTICATION = {LOGIN, AUTHENTICATE};
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoController.java
@@ -1,0 +1,27 @@
+package com.digitalojt.web.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.digitalojt.web.consts.UrlConsts;
+
+/**
+ * 分類情報管理画面コントローラークラス
+ * 
+ * @author KaitoDokan
+ *
+ */
+@Controller
+public class CategoryInfoController extends AbstractController {
+
+	/**
+	 * 初期表示
+	 * 
+	 * @return String(path)
+	 */
+	@GetMapping(UrlConsts.CATEGORY_INFO)
+	public String index() {
+
+		return "admin/categoryInfo/index";
+	}
+}

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfo/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfo/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html 
+	xmlns:th="http://www.thymeleaf.org"
+	th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}"
+>
+<head>
+	<title>InvenTrack</title>
+</head>
+
+<body>
+HelloWorld
+</body>
+
+</html>

--- a/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
+++ b/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
@@ -26,7 +26,7 @@
 				<a class="nav-link" th:href="@{'/admin/stockList'}">
 					<span>在庫一覧</span>
 				</a>
-				<a class="nav-link" th:href="@{'/admin/stockList'}">
+				<a class="nav-link" th:href="@{'/admin/categoryInfo'}">
 					<span>分類情報管理</span>
 				</a>
 				<a class="nav-link" th:href="@{'/admin/centerInfo'}">


### PR DESCRIPTION
## 概要
MVC①の指示内容の実装

ナビバーから分類情報管理画面への画面遷移
遷移先でのhelloworld表示

## 実装方針・詳細

・CategoryInfoController.javaの作成
・categoryInfo表示用HTMLファイルの作成
・navbar.htmlでの分類情報管理のリンク修正
・UrlConsts.javaへのURL追加

## 影響範囲

特になし

## テスト

特になし