### PR TITLE
MVC3の実装（検索フォーム作成、バリデーションチェック)

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/CategoryInfoConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/CategoryInfoConsts.java
@@ -5,42 +5,16 @@ package com.digitalojt.web.consts;
  * @author KaitoDokan
  */
 
-//定数クラスversion
-//public class CategoryInfoConsts {
-//
-//    public static final String FRAME = "フレーム";
-//    public static final String PROPELLER = "プロペラ";
-//    public static final String ELECTRIC_MOTOR = "電動モーター";
-//    public static final String ELECTRIC_SPEED_CONTROLLER = "電子速度調整器";
-//    public static final String BATTERY = "バッテリー";
-//    public static final String FLIGHT_CONTROLLER = "フライトコントローラー";
-//    public static final String REMOTE_CONTROLLER = "リモートコントローラー";
-//    public static final String RECEIVER = "受信機";
-//    public static final String GPS_MODULE = "GPSモジュール";
-//    public static final String CAMERA_SENSOR = "カメラ/センサー";
-//}
+public class CategoryInfoConsts {
 
-//enum version
-public enum CategoryInfoConsts {
-
-    FRAME("フレーム"),
-    PROPELLER("プロペラ"),
-    ELECTRIC_MOTOR("電動モーター"),
-    ELECTRIC_SPEED_CONTROLLER("電子速度調整器"),
-    BATTERY("バッテリー"),
-    FLIGHT_CONTROLLER("フライトコントローラー"),
-    REMOTE_CONTROLLER("リモートコントローラー"),
-    RECEIVER("受信機"),
-    GPS_MODULE("GPSモジュール"),
-    CAMERA_SENSOR("カメラ/センサー");
-
-    private final String category;
-
-    CategoryInfoConsts(String category) {
-        this.category = category;
-    }
-
-    public String getName() {
-        return category;
-    }
+    public static final String FRAME = "フレーム";
+    public static final String PROPELLER = "プロペラ";
+    public static final String ELECTRIC_MOTOR = "電動モーター";
+    public static final String ELECTRIC_SPEED_CONTROLLER = "電子速度調整器";
+    public static final String BATTERY = "バッテリー";
+    public static final String FLIGHT_CONTROLLER = "フライトコントローラー";
+    public static final String REMOTE_CONTROLLER = "リモートコントローラー";
+    public static final String RECEIVER = "受信機";
+    public static final String GPS_MODULE = "GPSモジュール";
+    public static final String CAMERA_SENSOR = "カメラ/センサー";
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
@@ -7,12 +7,15 @@ package com.digitalojt.web.consts;
  *
  */
 public class ErrorMessage {
-	
+
 	// ログイン情報の入力に誤りがあった場合に、出力するエラーメッセージのID
-	public static final String  LOGIN_WRONG_INPUT = "login.wrongInput";
+	public static final String LOGIN_WRONG_INPUT = "login.wrongInput";
 
 	// すべての項目が空の場合のエラーメッセージ
 	public static final String ALL_FIELDS_EMPTY_ERROR_MESSAGE = "allField.empty";
+
+	//項目が空の場合のエラーメッセージ
+	public static final String FIELDS_EMPTY_ERROR_MESSAGE = "Field.empty";
 
 	// 空文字検索に関するエラーメッセージ
 	public static final String UNEXPECTED_INPUT_ERROR_MESSAGE = "unexpected.input";
@@ -20,6 +23,9 @@ public class ErrorMessage {
 	// 不正な文字列を使用した検索に関するエラーメッセージ
 	public static final String INVALID_INPUT_ERROR_MESSAGE = "invalid.input";
 
-	// 文字超過に関するエラーメッセージ
+	// 文字超過に関するエラーメッセージ センター情報
 	public static final String CENTER_NAME_LENGTH_ERROR_MESSAGE = "centerName.length.wrongInput";
+
+	// 文字超過に関するエラーメッセージ 分類情報
+	public static final String CATEGORY_NAME_LENGTH_ERROR_MESSAGE = "categoryName.length.wrongInput";
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/SearchParams.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/SearchParams.java
@@ -9,5 +9,6 @@ package com.digitalojt.web.consts;
 public class SearchParams {
 
 	// 最大文字数
-	public static final int MAX_LENGTH = 20;
+	public static final int CENTER_MAX_LENGTH = 20;
+	public static final int CATEGORY_MAX_LENGTH = 15;
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
@@ -29,6 +29,9 @@ public class UrlConsts {
 	// 分類情報画面
 	public static final String  CATEGORY_INFO = "/admin/categoryInfo";
 	
+	// 分類情報画面 検索
+	public static final String CATEGORY_INFO_SEARCH = "/admin/categoryInfo/search";
+	
 	// 認証不要画面
 	public static final String[] NO_AUTHENTICATION = {LOGIN, AUTHENTICATE};
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoController.java
@@ -1,14 +1,22 @@
 package com.digitalojt.web.controller;
 
-import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
-import com.digitalojt.web.consts.CategoryInfoConsts;
 import com.digitalojt.web.consts.UrlConsts;
+import com.digitalojt.web.entity.CategoryInfo;
+import com.digitalojt.web.form.CategoryInfoForm;
+import com.digitalojt.web.service.CategoryInfoService;
+import com.digitalojt.web.util.MessageManager;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 /**
  * 分類情報管理画面コントローラークラス
@@ -17,7 +25,14 @@ import com.digitalojt.web.consts.UrlConsts;
  *
  */
 @Controller
+@RequiredArgsConstructor
 public class CategoryInfoController extends AbstractController {
+
+	/*分類情報サービス*/
+	private final CategoryInfoService categoryInfoService;
+
+	/** メッセージソース */
+	private final MessageSource messageSource;
 
 	/**
 	 * 初期表示
@@ -26,15 +41,42 @@ public class CategoryInfoController extends AbstractController {
 	 */
 	@GetMapping(UrlConsts.CATEGORY_INFO)
 	public String categoryInfoView(Model model) {
-		//基本パターン
-		//modelにカテゴリ情報定数クラスをセット
-//		model.addAttribute("categories", CategoryInfoConsts.class);
 
-		//Enum使用パターン
-		//カテゴリ情報Enumをセット
-		List<CategoryInfoConsts> categories = Arrays.asList(CategoryInfoConsts.values());
-		//modelにカテゴリ情報をセット
-		model.addAttribute("categories", categories);
+		// 分類情報画面に表示するデータを全件取得
+		List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+
+		//modelにカテゴリ情報定数クラスをセット
+		model.addAttribute("categoryInfoList", categoryInfoList);
+
+		return "admin/categoryInfo/index";
+	}
+
+	/**
+	 * 検索結果表示
+	 * 
+	 * @param model
+	 * @param form
+	 * @return
+	 */
+	@PostMapping(UrlConsts.CATEGORY_INFO_SEARCH)
+	public String search(Model model, @Valid CategoryInfoForm form, BindingResult bindingResult) {
+
+		// Valid項目チェック
+		if (bindingResult.hasErrors()) {
+
+			// エラーメッセージをプロパティファイルから取得
+			String errorMsg = MessageManager.getMessage(messageSource,
+					bindingResult.getGlobalError().getDefaultMessage());
+			model.addAttribute("errorMsg", errorMsg);
+			return "admin/categoryInfo/index";
+		}
+
+		// 在庫センター情報画面に表示するデータを取得
+		List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData(form.getCategoryName());
+
+		// 画面表示用に商品情報リストをセット
+		model.addAttribute("categoryInfoList", categoryInfoList);
+
 		return "admin/categoryInfo/index";
 	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CategoryInfo.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CategoryInfo.java
@@ -1,0 +1,49 @@
+package com.digitalojt.web.entity;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 分類情報Entity
+ * 
+ * @author KaitoDokan
+ *
+ */
+@Data
+@Getter
+@Setter
+@Entity
+public class CategoryInfo {
+
+	/**
+	 * 分類ID
+	 */
+	@Id
+	private int categoryId;
+	
+	/**
+	 * 分類名
+	 */
+	private String categoryName;
+	
+	/**
+	 * 論理削除フラグ
+	 */
+	private String deleteFlag;
+	
+	/**
+	 * 登録日
+	 */
+	private Timestamp createDate;
+
+	/**
+	 * 更新日
+	 */
+	private Timestamp updateDate;
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CategoryInfoForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CategoryInfoForm.java
@@ -5,7 +5,7 @@ import com.digitalojt.web.validation.CategoryInfoFormValidator;
 import lombok.Data;
 
 /**
- * 在庫センター情報画面のフォームクラス
+ * 分類情報画面のフォームクラス
  * 
  * @author KaitoDokan
  *
@@ -15,7 +15,7 @@ import lombok.Data;
 public class CategoryInfoForm {
 
 	/**
-	 * センター名
+	 * 分類名
 	 */
 	private String categoryName;
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CategoryInfoForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CategoryInfoForm.java
@@ -1,0 +1,22 @@
+package com.digitalojt.web.form;
+
+import com.digitalojt.web.validation.CategoryInfoFormValidator;
+
+import lombok.Data;
+
+/**
+ * 在庫センター情報画面のフォームクラス
+ * 
+ * @author KaitoDokan
+ *
+ */
+@Data
+@CategoryInfoFormValidator
+public class CategoryInfoForm {
+
+	/**
+	 * センター名
+	 */
+	private String categoryName;
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
@@ -1,0 +1,40 @@
+package com.digitalojt.web.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.digitalojt.web.entity.CenterInfo;
+
+/**
+ * 分類情報テーブルリポジトリー
+ *
+ * @author KaitoDokan
+ * CenterInfoからのコピー、未編集
+ */
+@Repository
+public interface CategoryInfoRepository extends JpaRepository<CenterInfo, Integer> {
+
+	/**
+	 * 引数に合致する在庫センター情報を取得
+	 * 
+	 * @param centerName
+	 * @param region
+	 * @param storageCapacityFrom
+	 * @param storageCapacityTo
+	 * @return paramで検索した結果
+	 */
+	@Query("SELECT s FROM CenterInfo s WHERE " +
+			"(:centerName = '' OR s.centerName LIKE %:centerName%) AND " +
+			"(:region = '' OR s.address LIKE %:region%) AND " +
+			"(:storageCapacityFrom IS NULL OR s.currentStorageCapacity >= :storageCapacityFrom) AND " +
+			"(:storageCapacityTo IS NULL OR s.currentStorageCapacity <= :storageCapacityTo) AND " +
+			"(s.operationalStatus = 0)")
+	List<CenterInfo> findByCenterNameAndRegionAndStorageCapacity(
+			String centerName,
+			String region,
+			Integer storageCapacityFrom,
+			Integer storageCapacityTo);
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
@@ -1,0 +1,142 @@
+package com.digitalojt.web.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.digitalojt.web.consts.CategoryInfoConsts;
+import com.digitalojt.web.entity.CategoryInfo;
+import com.digitalojt.web.repository.CategoryInfoRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 分類情報画面のサービスクラス
+ *
+ * @author KaitoDokan
+ * 未編集
+ */
+@Service
+@RequiredArgsConstructor
+public class CategoryInfoService {
+
+	/** 分類情報テーブル リポジトリー */
+	private final CategoryInfoRepository repository;
+
+	/**
+	 * 分類情報を全件検索で取得
+	 * 
+	 * @return
+	 */
+	public List<CategoryInfo> getCategoryInfoData() {
+
+		// 分類情報作成
+		List<CategoryInfo> categoryInfoList = createCategoryInfo();
+
+		return categoryInfoList;
+	}
+
+	/**
+	 * 引数に合致する在庫センター情報を取得
+	 * 
+	 * @param centerName
+	
+	 * @return 
+	 */
+	public List<CategoryInfo> getCategoryInfoData(String categoryName) {
+
+		// 分類情報作成
+		List<CategoryInfo> categoryInfoList = createCategoryInfo();
+
+		// 検索処理
+		categoryInfoList = searchCategoryInfoData(categoryInfoList, categoryName);
+
+		return categoryInfoList;
+	}
+
+	/**
+	 * 検索処理
+	 * 
+	 * @param categoryInfoList
+	 * @param categoryName
+	 * @return
+	 */
+	private List<CategoryInfo> searchCategoryInfoData(List<CategoryInfo> categoryInfoList,
+			String categoryName) {
+
+		List<CategoryInfo> hitCategoryInfoList = new ArrayList<>();
+
+		// 引数の文字列と合致する要素のみリストに追加
+		categoryInfoList.forEach(item -> {
+			if (categoryName.equals(item.getCategoryName())) {
+				hitCategoryInfoList.add(item);
+			}
+		});
+
+		return hitCategoryInfoList;
+	}
+
+	/**
+	 * 分類情報作成
+	 * 
+	 * @return
+	 */
+	private List<CategoryInfo> createCategoryInfo() {
+
+		List<CategoryInfo> categoryInfoList = new ArrayList<>();
+
+		// 1コード目作成
+		CategoryInfo categoryInfo = new CategoryInfo();
+		categoryInfo.setCategoryName(CategoryInfoConsts.FRAME);
+		categoryInfoList.add(categoryInfo);
+
+		// 2コード目作成
+		categoryInfo = new CategoryInfo();
+		categoryInfo.setCategoryName(CategoryInfoConsts.PROPELLER);
+		categoryInfoList.add(categoryInfo);
+
+		// 3コード目作成
+		categoryInfo = new CategoryInfo();
+		categoryInfo.setCategoryName(CategoryInfoConsts.ELECTRIC_MOTOR);
+		categoryInfoList.add(categoryInfo);
+
+		// 4コード目作成
+		categoryInfo = new CategoryInfo();
+		categoryInfo.setCategoryName(CategoryInfoConsts.ELECTRIC_SPEED_CONTROLLER);
+		categoryInfoList.add(categoryInfo);
+
+		// 5コード目作成
+		categoryInfo = new CategoryInfo();
+		categoryInfo.setCategoryName(CategoryInfoConsts.BATTERY);
+		categoryInfoList.add(categoryInfo);
+
+		// 6コード目作成
+		categoryInfo = new CategoryInfo();
+		categoryInfo.setCategoryName(CategoryInfoConsts.FLIGHT_CONTROLLER);
+		categoryInfoList.add(categoryInfo);
+
+		// 7コード目作成
+		categoryInfo = new CategoryInfo();
+		categoryInfo.setCategoryName(CategoryInfoConsts.REMOTE_CONTROLLER);
+		categoryInfoList.add(categoryInfo);
+
+		// 8コード目作成
+		categoryInfo = new CategoryInfo();
+		categoryInfo.setCategoryName(CategoryInfoConsts.RECEIVER);
+		categoryInfoList.add(categoryInfo);
+
+		// 9コード目作成
+		categoryInfo = new CategoryInfo();
+		categoryInfo.setCategoryName(CategoryInfoConsts.GPS_MODULE);
+		categoryInfoList.add(categoryInfo);
+
+		// 10コード目作成
+		categoryInfo = new CategoryInfo();
+		categoryInfo.setCategoryName(CategoryInfoConsts.CAMERA_SENSOR);
+		categoryInfoList.add(categoryInfo);
+
+		return categoryInfoList;
+	}
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
@@ -38,9 +38,9 @@ public class CategoryInfoService {
 	}
 
 	/**
-	 * 引数に合致する在庫センター情報を取得
+	 * 引数に合致する分類情報を取得
 	 * 
-	 * @param centerName
+	 * @param categoryName
 	
 	 * @return 
 	 */

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoFormValidator.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoFormValidator.java
@@ -1,0 +1,26 @@
+package com.digitalojt.web.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.digitalojt.web.consts.ErrorMessage;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * 分類情報画面のバリデーションチェック インターフェース
+ * 
+ * @author KaitoDokan
+ */
+@Constraint(validatedBy = CategoryInfoFormValidatorImpl.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CategoryInfoFormValidator {
+
+	String message() default ErrorMessage.ALL_FIELDS_EMPTY_ERROR_MESSAGE;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoFormValidatorImpl.java
@@ -53,7 +53,7 @@ public class CategoryInfoFormValidatorImpl implements ConstraintValidator<Catego
 			}
 
 			// 文字数チェック
-			if (form.getCategoryName().length() > SearchParams.MAX_LENGTH) {
+			if (form.getCategoryName().length() > SearchParams.CATEGORY_MAX_LENGTH) {
 				context.disableDefaultConstraintViolation();
 				context.buildConstraintViolationWithTemplate(ErrorMessage.CATEGORY_NAME_LENGTH_ERROR_MESSAGE)
 						.addConstraintViolation();

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoFormValidatorImpl.java
@@ -44,6 +44,14 @@ public class CategoryInfoFormValidatorImpl implements ConstraintValidator<Catego
 				return false;
 			}
 
+			// 不正文字列チェック
+			if (form.getCategoryName().equals(" ")|form.getCategoryName().equals("'")) {
+				context.disableDefaultConstraintViolation();
+				context.buildConstraintViolationWithTemplate(ErrorMessage.INVALID_INPUT_ERROR_MESSAGE)
+						.addConstraintViolation();
+				return false;
+			}
+
 			// 文字数チェック
 			if (form.getCategoryName().length() > SearchParams.MAX_LENGTH) {
 				context.disableDefaultConstraintViolation();

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoFormValidatorImpl.java
@@ -1,0 +1,58 @@
+package com.digitalojt.web.validation;
+
+import org.thymeleaf.util.StringUtils;
+
+import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.consts.SearchParams;
+import com.digitalojt.web.form.CategoryInfoForm;
+import com.digitalojt.web.util.ParmCheckUtil;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * 在庫センター情報画面のバリデーションチェック 実装クラス
+ * 
+ * @author KaitoDokan
+ */
+public class CategoryInfoFormValidatorImpl implements ConstraintValidator<CategoryInfoFormValidator, CategoryInfoForm> {
+
+	/**
+	 * バリデーションチェック
+	 */
+	@Override
+	public boolean isValid(CategoryInfoForm form, ConstraintValidatorContext context) {
+
+		boolean FieldsEmpty = StringUtils.isEmpty(form.getCategoryName());
+
+		// フィールドが空かをチェック
+		if (FieldsEmpty) {
+			context.disableDefaultConstraintViolation();
+			context.buildConstraintViolationWithTemplate(ErrorMessage.FIELDS_EMPTY_ERROR_MESSAGE)
+					.addConstraintViolation();
+			return false;
+		}
+
+		// 分類名のチェック
+		if (form.getCategoryName() != null) {
+
+			// 不正文字列チェック
+			if (ParmCheckUtil.isParameterInvalid(form.getCategoryName())) {
+				context.disableDefaultConstraintViolation();
+				context.buildConstraintViolationWithTemplate(ErrorMessage.INVALID_INPUT_ERROR_MESSAGE)
+						.addConstraintViolation();
+				return false;
+			}
+
+			// 文字数チェック
+			if (form.getCategoryName().length() > SearchParams.MAX_LENGTH) {
+				context.disableDefaultConstraintViolation();
+				context.buildConstraintViolationWithTemplate(ErrorMessage.CATEGORY_NAME_LENGTH_ERROR_MESSAGE)
+						.addConstraintViolation();
+				return false;
+			}
+		}
+		// その他のバリデーションに問題なければtrueを返す
+		return true;
+	}
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CenterInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CenterInfoFormValidatorImpl.java
@@ -46,7 +46,7 @@ public class CenterInfoFormValidatorImpl implements ConstraintValidator<CenterIn
 			}
 
 			// 文字数チェック
-			if (form.getCenterName().length() > SearchParams.MAX_LENGTH) {
+			if (form.getCenterName().length() > SearchParams.CENTER_MAX_LENGTH) {
 				context.disableDefaultConstraintViolation();
 				context.buildConstraintViolationWithTemplate(ErrorMessage.CENTER_NAME_LENGTH_ERROR_MESSAGE)
 						.addConstraintViolation();

--- a/DroneInventorySystem/src/main/resources/messages.properties
+++ b/DroneInventorySystem/src/main/resources/messages.properties
@@ -1,7 +1,7 @@
 # 画面共通
 allField.empty=すべてのフィールドが空です。少なくとも1つのフィールドに値を入力してください。
 unexpected.input=予期せぬ入力を検知しました。
-invalid.input=不正な文字列を検出しました。
+invalid.input=※不正な入力を検知しました。
 
 # ログイン画面
 login.wrongInput=管理者IDとパスワードの組み合わせが間違っています。

--- a/DroneInventorySystem/src/main/resources/messages.properties
+++ b/DroneInventorySystem/src/main/resources/messages.properties
@@ -8,3 +8,7 @@ login.wrongInput=管理者IDとパスワードの組み合わせが間違って�
 
 # 在庫センター情報画面
 centerName.length.wrongInput=センター名は20文字以内で入力してください。
+
+#分類センター情報画面
+Field.empty=※分類名を入力してください。
+categoryName.length.wrongInput=※分類名は1文字以上15文字以内で入力してください。

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfo/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfo/index.html
@@ -6,16 +6,41 @@
 </head>
 
 <body>
-	分類情報管理<br><br>
+	<div class="card shadow mb-4">
+		<div class="card-header py-3">
+			<h6 class="m-0 font-weight-bold text-primary">分類情報管理</h6>
+		</div>
 
-	<table th:each="category:${categories}" border="1" align="center" width="500">
-		<tr>
-			<td align="center"
-			th:text="${category.name}">
-			</td>
-		</tr>
-	</table>
+		<div class="card-body">
+			<!-- 検索フォーム -->
+			<div class="search-container">
+				<form class="form-inline" method="post" th:action="@{'/admin/categoryInfo/search'}"
+					th:object="${CategoryInfoForm}">
+					<label for="searchTerm" class="mr-2">検索条件</label>
 
+					<label for="searchTerm" class="mr-2">分類名</label>
+					<input type="text" id="searchTerm" name="categoryName" class="form-control mr-2">
+
+					<button type="submit" class="btn btn-primary">検索</button>
+				</form>
+
+				<!-- エラーメッセージの表示 -->
+				<div th:if="${errorMsg != null}" class="text-danger">
+					<p th:text="${errorMsg}"></p>
+				</div>
+			</div>
+
+			<!--分類情報テーブル-->
+			<div class="table-responsive">
+				<table class="table table-bordered" width="500">
+					<tr th:each="category:${categoryInfoList}">
+						<td align="center" th:text="${category.categoryName}">
+						</td>
+					</tr>
+				</table>
+			</div>
+		</div>
+	</div>
 </body>
 
 </html>


### PR DESCRIPTION
## 概要

MVC3の実装

## 実装方針・詳細
定数クラスの再修正(Enumを削除)
分類情報エンティティ
分類情報リポジトリを作成することでDBと接続(内容に関してはコピペのまま)
分類情報フォームを作成することでフォームから送信された情報を取得
分類情報サービスクラスを作成することでDBからの全権取得、検索
設計書に基づきエラーメッセージの編集


## 影響範囲

mvc2とのコンフリクトの可能性

## テスト

設計書の入力値に基づき正しいメッセージが出るか確認
