### PR TITLE
不正文字列のキャッチ方法修正

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/InvalidCharacter.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/InvalidCharacter.java
@@ -16,7 +16,9 @@ public enum InvalidCharacter {
     SEMICOLON(';'),
     DOLLAR_SIGN('$'),
     QUESTION_MARK('?'),
-    ASTERISK('*');
+    ASTERISK('*'),
+    SINGLE_QUOTE('\''),
+    HALF_SPACE(' ');
 
     private final char character;
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoFormValidatorImpl.java
@@ -44,14 +44,6 @@ public class CategoryInfoFormValidatorImpl implements ConstraintValidator<Catego
 				return false;
 			}
 
-			// 不正文字列チェック
-			if (form.getCategoryName().contains(" ")|form.getCategoryName().contains("'")) {
-				context.disableDefaultConstraintViolation();
-				context.buildConstraintViolationWithTemplate(ErrorMessage.INVALID_INPUT_ERROR_MESSAGE)
-						.addConstraintViolation();
-				return false;
-			}
-
 			// 文字数チェック
 			if (form.getCategoryName().length() > SearchParams.CATEGORY_MAX_LENGTH) {
 				context.disableDefaultConstraintViolation();


### PR DESCRIPTION
## 概要

バリデーションチェック方法を少し修正しました

## 実装方針・詳細
CategoryInfoFormValidatorImplでのキャッチを　ifで分岐→InvalidCharacterに指定文字列追加　と修正

## 影響範囲

とくになし

## テスト

挙動に変化なしです